### PR TITLE
Fix for hashes in filenames, better uri encoding

### DIFF
--- a/lib/Rapi/Fs/Module/FileTree.pm
+++ b/lib/Rapi/Fs/Module/FileTree.pm
@@ -135,7 +135,7 @@ sub _apply_node_view_url {
   my ($self, $Node, $mount, $for_ext) = @_;
   
   my $enc_path = $Node->path && $Node->path ne '/'
-    ? $self->b64_encode(join('/',$mount,$Node->path))
+    ? join('/',$self->b64_encode($mount),$self->b64_encode($Node->path))
     : $self->b64_encode($mount);
     
   $Node->view_url( $for_ext ? $self->local_url($enc_path) : $self->suburl($enc_path) );

--- a/lib/Rapi/Fs/Module/Role/Mounts.pm
+++ b/lib/Rapi/Fs/Module/Role/Mounts.pm
@@ -124,7 +124,7 @@ after 'BUILD' => sub {
 
 use URI::Escape;
 
-sub b64_encode { $_[1] }
+sub b64_encode { uri_escape($_[1]) }
 sub b64_decode { uri_unescape($_[1]) }
 
 

--- a/lib/Rapi/Fs/Module/Role/Mounts.pm
+++ b/lib/Rapi/Fs/Module/Role/Mounts.pm
@@ -124,7 +124,7 @@ after 'BUILD' => sub {
 
 use URI::Escape;
 
-sub b64_encode { uri_escape($_[1]) }
+sub b64_encode { uri_escape($_[1], '#&?%') }
 sub b64_decode { uri_unescape($_[1]) }
 
 


### PR DESCRIPTION
Somehow having a hash in the filename, or something like that, caused the uri to 404 error. This fixes it, and actually encodes the outgoing uri properly. wooo!
